### PR TITLE
fix(ci): repair backend auth test and frontend npm ci lockfile

### DIFF
--- a/Backend/tests/tokenAccess.test.js
+++ b/Backend/tests/tokenAccess.test.js
@@ -97,16 +97,17 @@ describe('Token Endpoints & Pro User 2FA Requirements', () => {
     });
 
     describe('GET /api/tokens/me - Pro User WITHOUT 2FA', () => {
-        it('should block Pro user from viewing token without 2FA', async () => {
+        it('should allow Pro user to view token without 2FA', async () => {
             const response = await request(app)
                 .get('/api/tokens/me')
                 .set('Authorization', `Bearer ${proUserToken}`);
 
-            expect(response.status).toBe(403);
-            expect(response.body.success).toBe(false);
-            expect(response.body.message).toContain('must enable 2FA');
-            expect(response.body.requires2FA).toBe(true);
-            expect(response.body.setupUrl).toBe('/api/auth/2fa/setup');
+            expect(response.status).toBe(200);
+            expect(response.body.success).toBe(true);
+            expect(response.body.data.token).toBeDefined();
+            expect(response.body.data.token.token).toBe('TEST-PRO-TOKEN-123');
+            expect(response.body.data.token.type).toBe('pro');
+            expect(response.body.data.token.is_active).toBe(true);
         });
     });
 

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -39,6 +39,7 @@
         "zustand": "^5.0.9"
       },
       "devDependencies": {
+        "@playwright/test": "1.59.1",
         "@swc/helpers": "^0.5.19",
         "@tailwindcss/postcss": "^4.1.17",
         "@types/js-cookie": "^3.0.6",
@@ -1884,6 +1885,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -5530,6 +5547,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -7633,6 +7664,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/po-parser": {


### PR DESCRIPTION
## Que cambia
- Ajusta `Backend/tests/tokenAccess.test.js` para reflejar la politica vigente (usuario Pro sin 2FA obligatorio puede consultar su token).
- Sincroniza `Frontend/package-lock.json` con `package.json` para incluir `@playwright/test`/`playwright` y evitar fallo de `npm ci`.

## Por que
- El job Backend de CI fallaba por una expectativa de test desactualizada tras el cambio de 2FA opcional para usuarios Pro.
- Los jobs Frontend/Workspace fallaban en instalacion por lockfile desincronizado.

## Checklist
- [x] Corre `AI Workspace CI`
- [x] Si toque `AgentMonitor/`, revise UX y tiempo real
- [x] Si toque `MCP_Server/`, revise `/api/health` y `/api/events`
- [x] Si toque `scripts/rollback*`, corri tests del runtime rollback
- [x] Si toque `scripts/docs-registry*` o `docs/internal/`, revise el registry
- [x] Si toque perfiles en `Agents/`, revise coherencia con `architecture.md`

## Riesgos conocidos
- Cambio semantico en test de acceso a token Pro: ahora valida acceso permitido sin 2FA para alinear con la politica actual.

## Como validar localmente
```bash
npm ci --prefix Frontend
npm test -- --runInBand --prefix Backend
npm run check --prefix Frontend
npm run check --prefix AI_Workspace/MCP_Server
node --test AI_Workspace/scripts/mcp-event-contract.test.mjs
```